### PR TITLE
Fix coverage collection for the jest test suite.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,18 +13,20 @@
 			"name": "Joe Lencioni",
 			"email": "joe.lencioni@gmail.com",
 			"url": "https://twitter.com/lencioni"
+		},
+		{
+			"name": "Gary Borton",
+			"email": "gdborton@gmail.com",
+			"url": "https://twitter.com/garyborton"
 		}
 	],
 	"main": "index.js",
 	"jest": {
 		"collectCoverage": false,
-		"collectCoverageFrom": [
-			"<rootDir>/*.js"
-		],
 		"roots": [
 			"<rootDir>/test"
 		],
-		"testRegex": "\\.js"
+		"testRegex": "test/.*\\.js$"
 	},
 	"scripts": {
 		"prepublish": "safe-publish-latest",


### PR DESCRIPTION
collectCoverageFrom is supposed to be an array of glob strings, <rootDir> isn't
valid syntax there.  In addition to removing collectCoverageFrom, I've updated
the test regex to only match against test files.  Both changes are needed to
get coverage working.

Updated output from running the test suite:
![image](https://cloud.githubusercontent.com/assets/4172067/23161128/bd6c56da-f7dd-11e6-805d-9553fc3c2c96.png)


Also just for FYI coverageDirectory only works in jest 19 AFAICT.