### PR TITLE
Fix an issue causing multiple wraps to exponentially add outer wrappers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ JestWrapper.prototype.use = function use(plugin) {
 		instance = wrap().extend(descriptorOrInstance.description, descriptorOrInstance);
 	}
 
-	return concatThis(this, [instance]);
+	return setThisWrappers(new JestWrapper(), [instance]);
 };
 
 wrap.register = function register(plugin) {

--- a/test/jest/core.js
+++ b/test/jest/core.js
@@ -14,6 +14,28 @@ describe('core JestWrapper semantics', function () {
 		return { description: 'i am pointless' };
 	};
 
+	var testingCount = 0;
+	var withTesting = function withTesting() {
+		return this.extend('(with Testing)', {
+			beforeEach: function withTestingBeforeEach() {
+				testingCount += 1;
+			}
+		});
+	};
+
+	var withFancyNoop = function withFancyNoop() {
+		return this.extend('(withFancyNoop)', {});
+	};
+
+	wrap()
+	.use(withTesting)
+	.use(withFancyNoop)
+	.describe('with multiple plugins', function () {
+		it('calls the plugin\'s hooks an appropriate number of times', function () {
+			assert.equal(testingCount, 1);
+		});
+	});
+
 	describe('#use()', function () {
 		var flag = false;
 		var withDescriptor = function withDescriptor() {
@@ -50,6 +72,25 @@ describe('core JestWrapper semantics', function () {
 			it('fails if not skipped', function () {
 				assert.equal(true, false); // boom
 			});
+		});
+	});
+
+	/**
+	 * Temporarily replace describe so that we can assert on the passed params.
+	 */
+	var originalDescribe = global.describe;
+	var passedDescription;
+	global.describe = function (description) {
+		passedDescription = description;
+		global.describe = originalDescribe; // revert to mocha's describe.
+		return originalDescribe.apply(this, arguments);
+	};
+
+	wrap()
+	.use(withFancyNoop)
+	.describe('wrapped descriptions', function () {
+		it('should pass', function () {
+			assert.equal(passedDescription, 'wrapped: (withFancyNoop):');
 		});
 	});
 


### PR DESCRIPTION
It appears that we were double wrapping JestWrap instances when calling .use
or .with<Wrapper> multiple times. When calling .use, we were correctly creating
a new instance of JestWrap with all the correct wrappers, but instead of
returning that new instance, we were appending it (and all its wrappers, which
include all of our current instance's wrappers) to our current instance's
wrappers.

Now we're just extending, and returning the new instance.

This is more or less copy/paste from the commits in mocha-wrap.