### PR TITLE
Add jest 20 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"pretest": "npm run --silent lint",
 		"test": "npm run --silent tests-only",
 		"posttest": "npm run --silent security",
-		"tests-only": "npm run --silent tape | faucet && npm run --silent jest19",
+		"tests-only": "npm run --silent tape | faucet && npm run --silent jest20",
 		"lint": "eslint '**/*.js'",
 		"security": "nsp check",
 		"tape": "node test/tape",
@@ -44,13 +44,18 @@
 		"install:jest18.x": "npm install --silent jest@18.x && jest --version",
 		"install:jest19.0": "npm install --silent jest@19.0.0 && jest --version",
 		"install:jest19.x": "npm install --silent jest@19.x && jest --version",
+		"install:jest20.0": "npm install --silent jest@20.0.1 && jest --version",
+		"install:jest20.x": "npm install --silent jest@20.x && jest --version",
 		"jest18.0": "npm run --silent install:jest18.0 && npm run --silent jest",
 		"jest18.x": "npm run --silent install:jest18.x && npm run --silent jest",
 		"jest18": "npm run --silent jest18.0 && npm run --silent jest18.x",
 		"jest19.0": "npm run --silent install:jest19.0 && npm run --silent jest",
 		"jest19.x": "npm run --silent install:jest19.x && npm run --silent jest",
 		"jest19": "npm run --silent jest19.0 && npm run --silent jest19.x",
-		"coverage": "npm run --silent jest19.0 && npm run --silent cover:clean && npm run --silent cover:tape && npm run --silent cover:jest && npm run --silent cover:merge && npm run --silent cover:check",
+		"jest20.0": "npm run --silent install:jest20.0 && npm run --silent jest",
+		"jest20.x": "npm run --silent install:jest20.x && npm run --silent jest",
+		"jest20": "npm run --silent jest20.0 && npm run --silent jest20.x",
+		"coverage": "npm run --silent jest20.0 && npm run --silent cover:clean && npm run --silent cover:tape && npm run --silent cover:jest && npm run --silent cover:merge && npm run --silent cover:check",
 		"cover:clean": "rimraf coverage",
 		"cover:check": "istanbul check-coverage && echo 100% code coverage, achievement unlocked!",
 		"cover:merge": "istanbul-merge --out coverage/coverage.raw.json 'coverage/*/coverage.raw.json' && istanbul report --format html",
@@ -101,7 +106,7 @@
 		"object.entries": "^1.0.4"
 	},
 	"peerDependencies": {
-		"jest": "^18.0.0 || ^19.0.0"
+		"jest": "^18.0.0 || ^19.0.0 || ^20.0.1"
 	},
 	"devDependencies": {
 		"@ljharb/eslint-config": "^11.0.0",
@@ -110,7 +115,7 @@
 		"istanbul": "1.1.0-alpha.1",
 		"istanbul-lib-coverage": "^1.0.2",
 		"istanbul-merge": "^1.1.1",
-		"jest": "^19.0.2",
+		"jest": "^20.0.1",
 		"nsp": "^2.6.3",
 		"parallelshell": "^2.0.0",
 		"rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"pretest": "npm run --silent lint",
 		"test": "npm run --silent tests-only",
 		"posttest": "npm run --silent security",
-		"tests-only": "npm run --silent tape | faucet && npm run --silent jest20",
+		"tests-only": "npm run --silent tape | faucet && npm run --silent jest20 && npm run --silent jest19 && npm run --silent jest18",
 		"lint": "eslint '**/*.js'",
 		"security": "nsp check",
 		"tape": "node test/tape",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
 		"is-symbol": "^1.0.1",
 		"isarray": "^1.0.0",
 		"object-inspect": "^1.2.2",
-		"object.entries": "^1.0.4"
+		"object.entries": "^1.0.4",
+		"semver": "^5.3.0"
 	},
 	"peerDependencies": {
 		"jest": "^18.0.0 || ^19.0.0 || ^20.0.1"


### PR DESCRIPTION
This adds Jest 20 support in a way that supports older versions.  I did this through a semver check against Jest's getVersion.

Note that I added support for 20.0.1 onward as 20.0.0 didn't support npm 2.